### PR TITLE
feat(attributes): Support DI service refs for MapTo attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,51 +1,60 @@
 {
-    "name": "backbrain/php-automapper",
-    "description": "PHP port of the popular automapper.org library",
-    "keywords": ["automapper", "mapping", "object", "mapper", "mapping", "object-mapper", "symfony"],
-    "homepage": "https://backbrainhq.github.io/php-automapper/",
-    "type": "library",
-    "license": "MIT",
-    "autoload": {
-        "psr-4": {
-            "Backbrain\\Automapper\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Backbrain\\Automapper\\Tests\\": "tests/"
-        }
-    },
-    "authors": [
-        {
-            "name": "Maximilian Reichel",
-            "email": "automapper@backbrain.io"
-        }
-    ],
-    "require": {
-        "php": ">=8.2",
-        "psr/log": "^3.0",
-        "psr/cache": "^3.0",
-        "symfony/property-access": "^6.0|^7.0",
-        "symfony/property-info": "^6.0|^7.0",
-        "symfony/finder": "^6.0|^7.0",
-        "symfony/expression-language": "^6.0|^7.0",
-        "symfony/uid": "^6.0|^7.0",
-        "symfony/clock": "^6.0|^7.0",
-        "phpstan/phpdoc-parser": "^1.26|^2.0",
-        "phpdocumentor/type-resolver": "^1.8",
-        "phpdocumentor/reflection-docblock": "^5.3",
-        "jawira/case-converter": "^3.5",
-        "nikic/php-parser": "^4.0|^5.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^11.0",
-        "phpstan/phpstan": "^1.10.35|^2",
-        "friendsofphp/php-cs-fixer": "^3.73",
-        "symfony/var-dumper": "*",
-        "doctrine/collections": "^2.2",
-        "symfony/framework-bundle": "^6.0|^7.0",
-        "symfony/filesystem": "^6.0|^7.0",
-        "symfony/dependency-injection": "^6.0|^7.0",
-        "symfony/http-kernel": "^6.0|^7.0"
+  "name": "backbrain/php-automapper",
+  "description": "PHP port of the popular automapper.org library",
+  "keywords": [
+    "automapper",
+    "mapping",
+    "object",
+    "mapper",
+    "mapping",
+    "object-mapper",
+    "symfony"
+  ],
+  "homepage": "https://backbrainhq.github.io/php-automapper/",
+  "type": "library",
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Backbrain\\Automapper\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Backbrain\\Automapper\\Tests\\": "tests/"
+    }
+  },
+  "authors": [
+    {
+      "name": "Maximilian Reichel",
+      "email": "automapper@backbrain.io"
+    }
+  ],
+  "require": {
+    "php": ">=8.2",
+    "psr/log": "^3.0",
+    "psr/cache": "^3.0",
+    "symfony/property-access": "^6.0|^7.0",
+    "symfony/property-info": "^6.0|^7.0",
+    "symfony/finder": "^6.0|^7.0",
+    "symfony/expression-language": "^6.0|^7.0",
+    "symfony/uid": "^6.0|^7.0",
+    "symfony/clock": "^6.0|^7.0",
+    "phpstan/phpdoc-parser": "^1.26|^2.0",
+    "phpdocumentor/type-resolver": "^1.8",
+    "phpdocumentor/reflection-docblock": "^5.3",
+    "jawira/case-converter": "^3.5",
+    "nikic/php-parser": "^4.0|^5.0",
+    "psr/container-implementation": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.0",
+    "phpstan/phpstan": "^2.1.22",
+    "friendsofphp/php-cs-fixer": "^3.73",
+    "symfony/var-dumper": "*",
+    "doctrine/collections": "^2.2",
+    "symfony/framework-bundle": "^6.0|^7.0",
+    "symfony/filesystem": "^6.0|^7.0",
+    "symfony/dependency-injection": "^6.0|^7.0",
+    "symfony/http-kernel": "^6.0|^7.0"
+  }
 }

--- a/src/Bundle/config/services.php
+++ b/src/Bundle/config/services.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Backbrain\Automapper\AutoMapper;
+use Backbrain\Automapper\Context\ResolutionContextProvider;
 use Backbrain\Automapper\Contract\AutoMapperInterface;
+use Backbrain\Automapper\Contract\ResolutionContextProviderInterface;
 use Backbrain\Automapper\Factory;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -16,12 +18,16 @@ return static function (ContainerConfigurator $container): void {
             '$expressionLanguage' => service('security.expression_language'),
             '$logger' => service('logger'),
             '$cacheItemPool' => service('cache.system'),
-        ])
-    ;
+            '$resolutionContextProvider' => service('backbrain_automapper_resolution_context_provider'),
+            '$container' => service('service_container'),
+        ]);
 
     $container->services()
         ->set('backbrain_automapper', AutoMapper::class)
         ->factory([service('backbrain_automapper_factory'), 'create'])
-        ->alias(AutoMapperInterface::class, 'backbrain_automapper')
-    ;
+        ->alias(AutoMapperInterface::class, 'backbrain_automapper');
+
+    $container->services()
+        ->set('backbrain_automapper_resolution_context_provider', ResolutionContextProvider::class)
+        ->alias(ResolutionContextProviderInterface::class, 'backbrain_automapper_resolution_context_provider');
 };

--- a/src/Context/ResolutionContext.php
+++ b/src/Context/ResolutionContext.php
@@ -9,14 +9,24 @@ use Backbrain\Automapper\Contract\MapInterface;
 use Backbrain\Automapper\Contract\MemberInterface;
 use Backbrain\Automapper\Contract\ResolutionContextInterface;
 
-readonly class ResolutionContext implements ResolutionContextInterface
+class ResolutionContext implements ResolutionContextInterface
 {
+    /**
+     * @var \ArrayAccess<string, mixed>
+     */
+    private \ArrayAccess $vars;
+
+    /**
+     * @param \ArrayAccess<string, mixed>|null $vars
+     */
     public function __construct(
-        private ?AutoMapperInterface $autoMapper = null,
-        private ?MapInterface $map = null,
-        private ?MemberInterface $member = null,
-        private mixed $source = null,
+        private readonly ?AutoMapperInterface $autoMapper = null,
+        private readonly ?MapInterface $map = null,
+        private readonly ?MemberInterface $member = null,
+        private readonly mixed $source = null,
+        ?\ArrayAccess $vars = null,
     ) {
+        $this->vars = $vars ?? new \ArrayObject();
     }
 
     public function getAutoMapper(): ?AutoMapperInterface
@@ -27,6 +37,16 @@ readonly class ResolutionContext implements ResolutionContextInterface
     public function getSource(): mixed
     {
         return $this->source;
+    }
+
+    /**
+     * Returns the variables associated with this context.
+     *
+     * @return \ArrayAccess<string, mixed> the variables
+     */
+    public function getVars(): \ArrayAccess
+    {
+        return $this->vars;
     }
 
     public function getMember(): ?MemberInterface

--- a/src/Context/ResolutionContextProvider.php
+++ b/src/Context/ResolutionContextProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Backbrain\Automapper\Context;
+
+use Backbrain\Automapper\Contract\AutoMapperInterface;
+use Backbrain\Automapper\Contract\MapInterface;
+use Backbrain\Automapper\Contract\MemberInterface;
+use Backbrain\Automapper\Contract\ResolutionContextInterface;
+use Backbrain\Automapper\Contract\ResolutionContextProviderInterface;
+use Psr\Container\ContainerInterface;
+
+class ResolutionContextProvider implements ResolutionContextProviderInterface
+{
+    public function __construct(
+        private ?ContainerInterface $container = null,
+    ) {
+    }
+
+    public function get(
+        AutoMapperInterface $autoMapper,
+        ?MapInterface $map = null,
+        ?MemberInterface $member = null,
+        mixed $source = null,
+        ?\ArrayAccess $vars = null,
+    ): ResolutionContextInterface {
+        $vars = $vars ?? new \ArrayObject();
+        $vars['container'] = $vars['container'] ?? $this->container;
+
+        return new ResolutionContext(
+            autoMapper: $autoMapper,
+            map: $map,
+            member: $member,
+            source: $source,
+            vars: $vars
+        );
+    }
+}

--- a/src/Contract/Attributes/MapTo.php
+++ b/src/Contract/Attributes/MapTo.php
@@ -12,20 +12,33 @@ class MapTo
 {
     private string $dest;
 
-    private ?MappingActionInterface $beforeMap;
-
-    private ?MappingActionInterface $afterMap;
-
-    private ?TypeConverterInterface $convertUsing;
+    /**
+     * @var MappingActionInterface|class-string|null
+     */
+    private MappingActionInterface|string|null $beforeMap;
 
     /**
-     * @param string                      $dest         The destination type name
-     * @param TypeConverterInterface|null $convertUsing Specifies a converter to use to convert the source object
-     * @param MappingActionInterface|null $beforeMap    Run this action before mapping
-     * @param MappingActionInterface|null $afterMap     Run this action after mapping
+     * @var MappingActionInterface|class-string|null
      */
-    public function __construct(string $dest, ?TypeConverterInterface $convertUsing = null, ?MappingActionInterface $beforeMap = null, ?MappingActionInterface $afterMap = null)
-    {
+    private MappingActionInterface|string|null $afterMap;
+
+    /**
+     * @var TypeConverterInterface|class-string|null
+     */
+    private TypeConverterInterface|string|null $convertUsing;
+
+    /**
+     * @param string                                   $dest         The destination type name
+     * @param TypeConverterInterface|class-string|null $convertUsing Specifies a converter to use to convert the source object
+     * @param MappingActionInterface|class-string|null $beforeMap    Run this action before mapping
+     * @param MappingActionInterface|class-string|null $afterMap     Run this action after mapping
+     */
+    public function __construct(
+        string $dest,
+        TypeConverterInterface|string|null $convertUsing = null,
+        MappingActionInterface|string|null $beforeMap = null,
+        MappingActionInterface|string|null $afterMap = null,
+    ) {
         $this->dest = $dest;
         $this->convertUsing = $convertUsing;
         $this->beforeMap = $beforeMap;
@@ -37,17 +50,17 @@ class MapTo
         return $this->dest;
     }
 
-    public function getBeforeMap(): ?MappingActionInterface
+    public function getBeforeMap(): MappingActionInterface|string|null
     {
         return $this->beforeMap;
     }
 
-    public function getAfterMap(): ?MappingActionInterface
+    public function getAfterMap(): MappingActionInterface|string|null
     {
         return $this->afterMap;
     }
 
-    public function getConvertUsing(): ?TypeConverterInterface
+    public function getConvertUsing(): TypeConverterInterface|string|null
     {
         return $this->convertUsing;
     }

--- a/src/Contract/ResolutionContextInterface.php
+++ b/src/Contract/ResolutionContextInterface.php
@@ -6,11 +6,42 @@ namespace Backbrain\Automapper\Contract;
 
 interface ResolutionContextInterface
 {
+    /**
+     * Returns the AutoMapper instance associated with this resolution context.
+     *
+     * This instance is responsible for performing the mapping operations
+     * and may contain configuration and state relevant to the mapping process.
+     */
     public function getAutoMapper(): ?AutoMapperInterface;
 
+    /**
+     * Returns the source object being mapped.
+     *
+     * This is the original object or data structure from which properties
+     * are being mapped to a destination object.
+     */
     public function getSource(): mixed;
 
+    /**
+     * Returns the destination property definition being mapped.
+     */
     public function getMember(): ?MemberInterface;
 
+    /**
+     * Returns the Map associated with this resolution context.
+     *
+     * This map contains the configuration and rules for how to map
+     * properties from the source to the destination.
+     */
     public function getMap(): ?MapInterface;
+
+    /**
+     * Returns an ArrayAccess object for storing variables.
+     *
+     * This allows for dynamic storage and retrieval of context-specific variables
+     * that can be used during the mapping process.
+     *
+     * @return \ArrayAccess<string, mixed>
+     */
+    public function getVars(): \ArrayAccess;
 }

--- a/src/Contract/ResolutionContextProviderInterface.php
+++ b/src/Contract/ResolutionContextProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Backbrain\Automapper\Contract;
+
+interface ResolutionContextProviderInterface
+{
+    /**
+     * Creates a new ResolutionContextInterface instance.
+     *
+     * @param AutoMapperInterface              $autoMapper the AutoMapper instance to use
+     * @param MapInterface|null                $map        the Map instance, if available
+     * @param MemberInterface|null             $member     the Member instance, if available
+     * @param mixed                            $source     the source data to map from
+     * @param \ArrayAccess<string, mixed>|null $vars       optional variables for the context
+     *
+     * @return ResolutionContextInterface the created resolution context
+     */
+    public function get(
+        AutoMapperInterface $autoMapper,
+        ?MapInterface $map = null,
+        ?MemberInterface $member = null,
+        mixed $source = null,
+        ?\ArrayAccess $vars = null,
+    ): ResolutionContextInterface;
+}


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the PHP Automapper library, focusing on dependency injection, context management, and code clarity. The main changes include adding a `ResolutionContextProvider` for more flexible context creation, updating constructors and service definitions to support dependency injection, and enhancing the handling of mapping actions and context variables.

### Dependency Injection and Context Management

* Added a new `ResolutionContextProvider` class implementing `ResolutionContextProviderInterface`, which centralizes the creation of `ResolutionContext` objects and allows injection of the service container and custom variables. (`src/Context/ResolutionContextProvider.php`)
* Updated constructors in `BaseMapper` and related service definitions to accept and inject `ResolutionContextProvider` and the Symfony service container, enabling better extensibility and testability. (`src/BaseMapper.php`, `src/Bundle/config/services.php`) [[1]](diffhunk://#diff-0f011e71711e0040a6cb3bc7c01969261a73ca86b67c53601d553a7c4bd6ca99R40-R43) [[2]](diffhunk://#diff-0f011e71711e0040a6cb3bc7c01969261a73ca86b67c53601d553a7c4bd6ca99L45-R60) [[3]](diffhunk://#diff-7af1af99a488171a3a559a6ad25f53f13c234dcea747cb4bf956cbf9a3862d8eL19-R32)

### Resolution Context Enhancements

* Refactored `ResolutionContext` to store and expose arbitrary variables via an `ArrayAccess` object, allowing context-aware mapping and easier access to injected dependencies. (`src/Context/ResolutionContext.php`) [[1]](diffhunk://#diff-670688f76a02670b370b4bae299595ffdb8e8746c69ab72a21c6f7d05e40e61aL12-R29) [[2]](diffhunk://#diff-670688f76a02670b370b4bae299595ffdb8e8746c69ab72a21c6f7d05e40e61aR42-R51)
* Updated usages of `newResolutionContext` and related context creation logic across the codebase to utilize the new provider and variable management. (`src/AutoMapper.php`, `src/BaseMapper.php`)

### Mapping Action and Attribute Improvements

* Modified the `MapTo` attribute to allow mapping actions and type converters to be specified as either instances or class-string names, improving flexibility for attribute-based configuration. (`src/Contract/Attributes/MapTo.php`)

### Miscellaneous Refactoring

* Improved code readability and maintainability by reformatting method calls and array definitions for clarity, and updating package dependencies in `composer.json`. (`composer.json`, various locations) [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4-R12) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L38-R51)

These changes collectively make the library more modular, extensible, and ready for advanced dependency injection scenarios.