### PR TITLE
chore: more tests

### DIFF
--- a/tests/Context/MutateContextExceptionTest.php
+++ b/tests/Context/MutateContextExceptionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Backbrain\Automapper\Tests\Context;
+
+use Backbrain\Automapper\Contract\Builder\Config;
+use Backbrain\Automapper\Contract\Builder\Options;
+use Backbrain\Automapper\Exceptions\MapperException;
+use Backbrain\Automapper\MapperConfiguration;
+use Backbrain\Automapper\Tests\Fixtures\ScalarDest;
+use Backbrain\Automapper\Tests\Fixtures\ScalarSrc;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class MutateContextExceptionTest extends TestCase
+{
+    public function testMutateAppendsContextWhenMemberMappingFails(): void
+    {
+        $config = new MapperConfiguration(fn (Config $config) => $config
+            ->createMap(ScalarSrc::class, ScalarDest::class)
+            // Force a member mapping that cannot be resolved: array -> string without converter
+            ->forMember('aString', fn (Options $opts) => $opts->mapFrom(fn (ScalarSrc $source) => $source->anArray))
+        );
+
+        $mapper = $config->createMapper();
+
+        $source = new ScalarSrc('John', 1, 1.0);
+        $dest = new ScalarDest();
+
+        try {
+            $mapper->mutate($source, $dest);
+            self::fail('Expected MapperException to be thrown');
+        } catch (MapperException $e) {
+            self::assertSame(MapperException::MISSING_MAP, $e->getCode());
+            $msg = $e->getMessage();
+            self::assertStringContainsString('Context: ', $msg);
+            self::assertStringContainsString('path=(root)', $msg);
+            self::assertStringContainsString('depth=0', $msg);
+            self::assertStringContainsString('source='.ScalarSrc::class, $msg);
+            self::assertStringContainsString('dest='.ScalarDest::class, $msg);
+            self::assertStringContainsString('map='.ScalarSrc::class.' => '.ScalarDest::class, $msg);
+        }
+    }
+}

--- a/tests/Functional/MapIterableErrorsTest.php
+++ b/tests/Functional/MapIterableErrorsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Backbrain\Automapper\Tests\Functional;
+
+use Backbrain\Automapper\Contract\Builder\Config;
+use Backbrain\Automapper\MapperConfiguration;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class MapIterableErrorsTest extends TestCase
+{
+    public function testMapIterableThrowsWhenConverterReturnsNonIterable(): void
+    {
+        $config = new MapperConfiguration(fn (Config $config) => $config
+            ->createMap('array', 'string')
+            ->convertUsing(fn (array $source): string => 'not-iterable')
+        );
+
+        $mapper = $config->createMapper();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Type is not a collection');
+
+        // Destination type is not a collection (plain string), but a map exists and returns a non-iterable
+        $mapper->mapIterable([1, 2, 3], 'string');
+    }
+}


### PR DESCRIPTION
This pull request adds two new test cases to improve error handling coverage for the mapping library. The tests ensure that exceptions are thrown with the appropriate context and messages when mapping fails due to configuration or type errors.

**Error handling and exception coverage:**

* Added `MutateContextExceptionTest` to verify that when member mapping fails (e.g., mapping an array to a string without a converter), a `MapperException` is thrown with detailed context information in the message. (`tests/Context/MutateContextExceptionTest.php`)
* Added `MapIterableErrorsTest` to ensure that calling `mapIterable` with a converter returning a non-iterable (e.g., string instead of iterable) throws a `LogicException` with an appropriate error message. (`tests/Functional/MapIterableErrorsTest.php`)