### PR TITLE
fix: skip ignored members before reading source property

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -119,6 +119,10 @@ class AutoMapper extends BaseMapper
         }
 
         foreach ($this->membersFor($map) as $member) {
+            if ($member->isIgnored()) {
+                continue;
+            }
+
             [$sourcePropertyValue, $ok] = $this->memberSourceValueFor($map, $member, $srcValue, $ctx);
             if (!$ok) {
                 $this->logger->warning('Cannot access source property.', [
@@ -260,10 +264,6 @@ class AutoMapper extends BaseMapper
 
     private function memberDestinationValuePut(MemberInterface $member, object $dest, mixed $value, MappingContext $ctx): void
     {
-        if ($member->isIgnored()) {
-            return;
-        }
-
         // @phpstan-ignore-next-line
         if (method_exists($this->propertyInfoExtractor, 'getType')) {
             $type = $this->propertyInfoExtractor->getType(get_class($dest), $member->getDestinationProperty());

--- a/tests/Functional/MapTest.php
+++ b/tests/Functional/MapTest.php
@@ -19,6 +19,7 @@ use Backbrain\Automapper\Tests\Fixtures\ScalarDestSnakeCase;
 use Backbrain\Automapper\Tests\Fixtures\ScalarDestWithAnotherString;
 use Backbrain\Automapper\Tests\Fixtures\ScalarSrc;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class MapTest extends TestCase
 {
@@ -175,5 +176,51 @@ class MapTest extends TestCase
         $destination = $autoMapper->map($source, ObjectDestSameType::class);
 
         $this->assertSame($source->getObj(), $destination->getObj());
+    }
+
+    public function testIgnoredMemberWithNoSourcePropertyDoesNotLogWarning()
+    {
+        $warningMembers = [];
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->method('warning')->willReturnCallback(
+            function (string $message, array $context) use (&$warningMembers) {
+                if ('Cannot access source property.' === $message) {
+                    $warningMembers[] = $context['member'] ?? null;
+                }
+            }
+        );
+
+        $config = new MapperConfiguration(fn (Config $config) => $config
+            ->createMap(ScalarSrc::class, ScalarDestWithAnotherString::class)
+            ->forMember('anotherString', fn (Options $opts) => $opts->ignore())
+        );
+
+        $autoMapper = new AutoMapper($config, logger: $logger);
+
+        $source = new ScalarSrc('John Doe', 30, 1.75);
+        $destination = $autoMapper->map($source, ScalarDestWithAnotherString::class);
+
+        $this->assertInstanceOf(ScalarDestWithAnotherString::class, $destination);
+        $this->assertNotContains('anotherString', $warningMembers, 'Ignored member "anotherString" should not trigger a source property warning');
+        $this->assertEquals($source->aString, $destination->aString);
+        $this->assertEquals($source->anInt, $destination->anInt);
+    }
+
+    public function testIgnoredMemberSkipsSourceReadAndDestinationWrite()
+    {
+        $config = new MapperConfiguration(fn (Config $config) => $config
+            ->createMap(ScalarSrc::class, ScalarDest::class)
+            ->forMember('aString', fn (Options $opts) => $opts->ignore())
+        );
+
+        $autoMapper = $config->createMapper();
+
+        $source = new ScalarSrc('John Doe', 30, 1.75);
+        $destination = $autoMapper->map($source, ScalarDest::class);
+
+        $this->assertInstanceOf(ScalarDest::class, $destination);
+        $this->assertEquals('', $destination->aString);
+        $this->assertEquals($source->anInt, $destination->anInt);
+        $this->assertEquals($source->aFloat, $destination->aFloat);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes spurious `WARNING` logs ("Cannot access source property") emitted for every mapping member marked with `ignore()` when the corresponding property doesn't exist on the source object
- Moves the `isIgnored()` check to the top of the mapping loop in `mapType()`, before `memberSourceValueFor()` is called
- Removes the now-redundant `isIgnored()` guard inside `memberDestinationValuePut()`

## Root cause

The mapping loop in `AutoMapper::mapType()` iterated all destination members and immediately attempted to read the source property. The `isIgnored()` check only existed inside `memberDestinationValuePut()`, which was never reached when the source read failed — causing a warning + `continue` on every ignored member without a matching source property.

## Test plan

- [x] Added `testIgnoredMemberWithNoSourcePropertyDoesNotLogWarning` — verifies no warning is logged for ignored members with missing source properties
- [x] Added `testIgnoredMemberSkipsSourceReadAndDestinationWrite` — verifies ignored members retain their default value when using `map()`
- [x] Full test suite passes (141 tests, 387 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)